### PR TITLE
PSX: Re/Assign Start and Select

### DIFF
--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -1484,6 +1484,8 @@ const int WSMap[]   = { 0, 2, 3, 1, 4, 6, 7, 5, 9, 10, 8, 11 };
             case OEPSXButtonR1:
                 return [[pad rightShoulder] isPressed];
             case OEPSXButtonStart:
+                return [[pad rightTrigger] isPressed];
+            case OEPSXButtonSelect:
                 return [[pad leftTrigger] isPressed];
             default:
                 break;


### PR DESCRIPTION
For PSX controller, extended gamepad:
Assigned Select key assignment to trigger L2
Reassigned Start key to trigger R2