### PR TITLE
Speed up app launch (specially on large libraries)

### DIFF
--- a/Provenance/Game Library/PVGameImporter.h
+++ b/Provenance/Game Library/PVGameImporter.h
@@ -10,7 +10,7 @@
 
 typedef void (^PVGameImporterImportStartedHandler)(NSString *path);
 typedef void (^PVGameImporterCompletionHandler)(BOOL encounteredConflicts);
-typedef void (^PVGameImporterFinishedImportingGameHandler)(NSString *md5Hash);
+typedef void (^PVGameImporterFinishedImportingGameHandler)(NSString *md5Hash, BOOL modified);
 typedef void (^PVGameImporterFinishedGettingArtworkHandler)(NSString *artworkURL);
 
 @class PVGame;

--- a/Provenance/Game Library/PVGameImporter.m
+++ b/Provenance/Game Library/PVGameImporter.m
@@ -387,6 +387,7 @@
                 [realm commitWriteTransaction];
             }
 
+            BOOL modified = NO;
             if ([game requiresSync])
             {
                 if (self.importStartedHandler)
@@ -397,13 +398,14 @@
                 }
                 
                 [self lookupInfoForGame:game];
+                modified = YES;
             }
             
             if (self.finishedImportHandler)
             {
                 NSString *md5 = [game md5Hash];
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    self.finishedImportHandler(md5);
+                    self.finishedImportHandler(md5, modified);
                 });
             }
             

--- a/Provenance/Game Library/PVGameLibraryViewController.m
+++ b/Provenance/Game Library/PVGameLibraryViewController.m
@@ -491,8 +491,10 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
         [hud setMode:MBProgressHUDModeIndeterminate];
         [hud setLabelText:[NSString stringWithFormat:@"Importing %@", [path lastPathComponent]]];
     }];
-    [self.gameImporter setFinishedImportHandler:^(NSString *md5) {
-        [weakSelf finishedImportingGameWithMD5:md5];
+    [self.gameImporter setFinishedImportHandler:^(NSString *md5, BOOL modified) {
+        // This callback is always called,
+        // even if the started handler was not called because it didn't require a refresh.
+        [weakSelf finishedImportingGameWithMD5:md5 modified:modified];
     }];
     [self.gameImporter setFinishedArtworkHandler:^(NSString *url) {
         [weakSelf finishedDownloadingArtworkForURL:url];
@@ -642,13 +644,16 @@ static NSString *_reuseIdentifier = @"PVGameLibraryCollectionViewCell";
     self.mustRefreshDataSource = NO;
 }
 
-- (void)finishedImportingGameWithMD5:(NSString *)md5
+- (void)finishedImportingGameWithMD5:(NSString *)md5 modified:(BOOL)modified;
 {
     MBProgressHUD *hud = [MBProgressHUD HUDForView:self.view];
     [hud hide:YES];
 
-    [self fetchGames];
-    [self.collectionView reloadData];
+    // Only refresh the whole collection if game was modified.
+    if (modified) {
+        [self fetchGames];
+        [self.collectionView reloadData];
+    }
 
     // code below is simply to animate updates... currently crashy
 


### PR DESCRIPTION
Only trigger a library refresh if a rom lookup was triggered.